### PR TITLE
Start ranking microservice

### DIFF
--- a/ARCHITECTURE_PLAN.md
+++ b/ARCHITECTURE_PLAN.md
@@ -1,0 +1,51 @@
+# Setup Plan: Building Rankle with an Agent-Native Architecture
+
+This repository currently contains only the basic Nx scaffolding for an Angular front end and a minimal tRPC backend. The following plan describes how to establish the missing pieces so that future features can be built on top of a well-structured, event-driven foundation. The aim is to use Convex as a reactive database, retain tRPC for typed APIs, and allow either Angular or Vue on the frontend.
+
+## 1. Backend Setup
+
+### 1.1 Service Decomposition
+- **Domain‑Driven Design:** Identify bounded contexts such as `Ranking`, `Images`, and `User`. Each context will have its own microservice implemented in Nx.
+- **Microservices:** Each service becomes its own Nx project exposing tRPC procedures. Services communicate via events rather than direct calls.
+- **Database per Service:** Use Convex from the start. Each service owns its own tables, and Convex's reactive queries keep the front end in sync with event updates.
+
+### 1.2 Event‑Driven Architecture
+- Introduce a message bus (e.g., Kafka or NATS). A service publishes domain events such as `ImageRanked` or `ImageAdded`.
+- Other services subscribe to these events to maintain additional read models or trigger workflows. tRPC remains for command/query APIs.
+
+### 1.3 Hexagonal Structure
+- For each service, move business logic into a "domain" folder with interfaces (ports) for persistence, events, and third‑party APIs.
+- Implement adapters in an "infrastructure" layer. This makes it easy to swap the database with Convex and to test business logic in isolation.
+
+### 1.4 Containerization and Sidecars
+- Package every service in a Docker container. Add a sidecar container for logging and security so that core service code stays focused on domain behavior.
+- Use docker-compose or Nx executors to orchestrate local development with the message bus and Convex.
+
+### 1.5 Testing
+- Follow a test-driven workflow. Unit tests run against the domain layer via mock ports. Integration tests spin up the containers (including Convex) to verify end‑to‑end flows.
+
+## 2. Frontend Evolution
+
+### 2.1 Micro‑Frontends
+- Build the UI from the beginning as a set of micro-frontends (e.g., `ranking`, `image-upload`). Nx supports Angular micro-frontends out of the box.
+- If the team prefers, a Vue micro-frontend can replace or coexist with Angular modules. The only restriction is to avoid React.
+
+### 2.2 tRPC Client and Real-time Updates
+- Continue using tRPC for typed API calls. Convex’s reactive queries can be consumed directly in Angular/Vue components to update rankings in real time when events occur.
+
+### 2.3 Human-in-the-loop Views
+- Add UI components for inspecting agent decisions or ranking changes. Display the history of events and allow users to approve or revert actions as suggested in the report.
+
+## 3. Gateway and Security
+
+- Route all external LLM or AI tool traffic through an AI Gateway for observability, prompt management, and token-based rate limiting.
+- Adopt an API-first approach for all service endpoints so agents can interact consistently with tRPC procedures.
+
+## 4. Roadmap
+
+1. **Foundations** – Set up Convex and the message bus. Create the first microservice (e.g., ranking) with a hexagonal structure and run it in a container.
+2. **Incremental Services** – Introduce new services (e.g., user profiles, image storage). Each service publishes events and exposes tRPC APIs.
+3. **Frontend Modularization** – Start building the UI as micro-frontends in Angular or Vue. Consume events through Convex’s reactivity to keep the UI fresh.
+4. **Operational Hardening** – Add sidecars for observability, implement the AI Gateway, and enforce test-driven CI pipelines.
+
+Following this roadmap will let Rankle grow into an agent-native, event-driven architecture that embraces tRPC, a reactive database, and modular frontend components without adopting React.

--- a/libs/backend/ranking-service/.babelrc
+++ b/libs/backend/ranking-service/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/js/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/backend/ranking-service/.eslintrc.json
+++ b/libs/backend/ranking-service/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/backend/ranking-service/README.md
+++ b/libs/backend/ranking-service/README.md
@@ -1,0 +1,11 @@
+# backend-ranking-service
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test backend-ranking-service` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint backend-ranking-service` to execute the lint via [ESLint](https://eslint.org/).

--- a/libs/backend/ranking-service/jest.config.ts
+++ b/libs/backend/ranking-service/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: 'backend-ranking-service',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/libs/backend/ranking-service',
+};

--- a/libs/backend/ranking-service/project.json
+++ b/libs/backend/ranking-service/project.json
@@ -1,0 +1,30 @@
+{
+  "name": "backend-ranking-service",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/backend/ranking-service/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["libs/backend/ranking-service/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/backend/ranking-service/jest.config.ts",
+        "passWithNoTests": true
+      },
+      "configurations": {
+        "ci": {
+          "ci": true,
+          "codeCoverage": true
+        }
+      }
+    }
+  },
+  "tags": []
+}

--- a/libs/backend/ranking-service/src/index.ts
+++ b/libs/backend/ranking-service/src/index.ts
@@ -1,0 +1,5 @@
+export * from './lib/domain/ranking-service';
+export * from './lib/domain/interfaces';
+export * from './lib/trpc-router';
+export * from './lib/infrastructure/memory-repository';
+export * from './lib/infrastructure/event-bus';

--- a/libs/backend/ranking-service/src/lib/backend-ranking-service.spec.ts
+++ b/libs/backend/ranking-service/src/lib/backend-ranking-service.spec.ts
@@ -1,0 +1,14 @@
+import { RankingService } from './domain/ranking-service';
+import { MemoryRankingRepository } from './infrastructure/memory-repository';
+import { InMemoryEventBus } from './infrastructure/event-bus';
+
+describe('RankingService', () => {
+  it('updates elo ratings', async () => {
+    const repo = new MemoryRankingRepository();
+    const service = new RankingService(repo, new InMemoryEventBus());
+    await service.rankPair('A', 'B', 'A');
+    const ranks = await repo.listRankings();
+    const a = ranks.find(r => r.id === 'A')!;
+    expect(a.elo_rating).not.toBe(1000);
+  });
+});

--- a/libs/backend/ranking-service/src/lib/domain/elo.ts
+++ b/libs/backend/ranking-service/src/lib/domain/elo.ts
@@ -1,0 +1,15 @@
+export function calculateElo(ratingA: number, ratingB: number, winner: 'A' | 'B'): [number, number] {
+  const k = 32;
+  const probA = 1 / (1 + Math.pow(10, (ratingB - ratingA) / 400));
+  const probB = 1 / (1 + Math.pow(10, (ratingA - ratingB) / 400));
+  let newA = ratingA;
+  let newB = ratingB;
+  if (winner === 'A') {
+    newA += k * (1 - probA);
+    newB += k * (0 - probB);
+  } else {
+    newA += k * (0 - probA);
+    newB += k * (1 - probB);
+  }
+  return [Math.round(newA), Math.round(newB)];
+}

--- a/libs/backend/ranking-service/src/lib/domain/interfaces.ts
+++ b/libs/backend/ranking-service/src/lib/domain/interfaces.ts
@@ -1,0 +1,10 @@
+import { ImageRank } from '@rankle/shared/data-models';
+
+export interface RankingRepository {
+  listRankings(): Promise<ImageRank[]>;
+  updateRanking(id: string, rating: number): Promise<void>;
+}
+
+export interface EventBus {
+  publish(event: { type: string; payload: unknown }): Promise<void>;
+}

--- a/libs/backend/ranking-service/src/lib/domain/ranking-service.ts
+++ b/libs/backend/ranking-service/src/lib/domain/ranking-service.ts
@@ -1,0 +1,24 @@
+import { calculateElo } from './elo';
+import { RankingRepository, EventBus } from './interfaces';
+
+export class RankingService {
+  constructor(private repo: RankingRepository, private bus: EventBus) {}
+
+  async rankPair(idA: string, idB: string, winner: 'A' | 'B'): Promise<void> {
+    const rankings = await this.repo.listRankings();
+    const a = rankings.find(r => r.id === idA);
+    const b = rankings.find(r => r.id === idB);
+    if (!a || !b) {
+      throw new Error('missing image');
+    }
+    const [newA, newB] = calculateElo(a.elo_rating, b.elo_rating, winner);
+    await this.repo.updateRanking(idA, newA);
+    await this.repo.updateRanking(idB, newB);
+    await this.bus.publish({ type: 'ranking.updated', payload: { idA, idB, newA, newB } });
+  }
+
+  async getRandomPair() {
+    const all = await this.repo.listRankings();
+    return all.slice(0, 2);
+  }
+}

--- a/libs/backend/ranking-service/src/lib/infrastructure/event-bus.ts
+++ b/libs/backend/ranking-service/src/lib/infrastructure/event-bus.ts
@@ -1,0 +1,14 @@
+import { EventBus } from '../domain/interfaces';
+import { EventEmitter } from 'events';
+
+export class InMemoryEventBus implements EventBus {
+  constructor(private emitter = new EventEmitter()) {}
+
+  async publish(event: { type: string; payload: unknown }): Promise<void> {
+    this.emitter.emit(event.type, event.payload);
+  }
+
+  on(event: string, listener: (payload: unknown) => void) {
+    this.emitter.on(event, listener);
+  }
+}

--- a/libs/backend/ranking-service/src/lib/infrastructure/memory-repository.ts
+++ b/libs/backend/ranking-service/src/lib/infrastructure/memory-repository.ts
@@ -1,0 +1,23 @@
+import { ImageRank } from '@rankle/shared/data-models';
+import { RankingRepository } from '../domain/interfaces';
+
+const data: ImageRank[] = [
+  { id: 'A', elo_rating: 1000, capture_time: '' },
+  { id: 'B', elo_rating: 1000, capture_time: '' },
+  { id: 'C', elo_rating: 1000, capture_time: '' },
+];
+
+export class MemoryRankingRepository implements RankingRepository {
+  private rankings = [...data];
+
+  async listRankings(): Promise<ImageRank[]> {
+    return this.rankings;
+  }
+
+  async updateRanking(id: string, rating: number): Promise<void> {
+    const idx = this.rankings.findIndex(r => r.id === id);
+    if (idx !== -1) {
+      this.rankings[idx] = { ...this.rankings[idx], elo_rating: rating };
+    }
+  }
+}

--- a/libs/backend/ranking-service/src/lib/trpc-router.ts
+++ b/libs/backend/ranking-service/src/lib/trpc-router.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+import { t } from '@rankle/backend/rankle-core';
+import { RankingService } from './domain/ranking-service';
+import { MemoryRankingRepository } from './infrastructure/memory-repository';
+import { InMemoryEventBus } from './infrastructure/event-bus';
+
+const service = new RankingService(new MemoryRankingRepository(), new InMemoryEventBus());
+
+export const rankingRouter = t.router({
+  randomPair: t.procedure.query(async () => {
+    const pair = await service.getRandomPair();
+    return { data: pair };
+  }),
+  rankPair: t.procedure
+    .input(z.object({ idA: z.string(), idB: z.string(), winner: z.enum(['A', 'B']) }))
+    .mutation(async ({ input }) => {
+      await service.rankPair(input.idA, input.idB, input.winner);
+      return { success: true };
+    }),
+});

--- a/libs/backend/ranking-service/tsconfig.json
+++ b/libs/backend/ranking-service/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/backend/ranking-service/tsconfig.lib.json
+++ b/libs/backend/ranking-service/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/backend/ranking-service/tsconfig.spec.json
+++ b/libs/backend/ranking-service/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/backend/rankle-core/src/lib/router.ts
+++ b/libs/backend/rankle-core/src/lib/router.ts
@@ -1,51 +1,11 @@
-import { ImageMetadata } from '@rankle/shared/data-models';
-import { z } from 'zod';
-import { IMAGES, RANKINGS } from './TMP_image-data';
-import { calculateElo } from './TMP_ranking-utils';
 import { t } from './context';
-
-type RandomResponse = {
-  data: ImageMetadata[];
-  error: any | null;
-};
-type RankPairResponse = {
-  success: boolean;
-  error: any | null;
-};
+import { rankingRouter } from '@rankle/backend/ranking-service';
 
 export const appRouter = t.router({
   hello: t.procedure.query(async ({ ctx }): Promise<string> => {
-    // console.log({ ctxTest: ctx.test });
     return `Hello! testHeader: ${ctx.test}`;
   }),
-  randomPair: t.procedure.query(async (): Promise<RandomResponse> => {
-    return {
-      data: IMAGES,
-      error: null,
-    };
-  }),
-  rankPair: t.procedure
-    .input(z.object({ imageA: z.string(), imageB: z.string(), winner: z.enum(['A', 'B']) }))
-    .mutation(async ({ input }): Promise<RankPairResponse> => {
-      const imageAIndex = RANKINGS.findIndex(i => i.id === input.imageA);
-      const imageBIndex = RANKINGS.findIndex(i => i.id === input.imageB);
-      if (imageAIndex === -1 || imageBIndex === -1) {
-        return { success: false, error: 'missing Image' };
-      }
-
-      const [newRatingA, newRatingB] = calculateElo(
-        RANKINGS[imageAIndex].elo_rating,
-        RANKINGS[imageBIndex].elo_rating,
-        input.winner,
-      );
-
-      RANKINGS[imageAIndex] = { ...RANKINGS[imageAIndex], elo_rating: newRatingA };
-      RANKINGS[imageBIndex] = { ...RANKINGS[imageBIndex], elo_rating: newRatingB };
-
-      console.log(RANKINGS);
-
-      return { success: true, error: null };
-    }),
+  ranking: rankingRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@rankle/backend/ranking-service": ["libs/backend/ranking-service/src/index.ts"],
       "@rankle/backend/rankle-core": ["libs/backend/rankle-core/src/index.ts"],
       "@rankle/frontend/utils/api-client": ["libs/frontend/utils/api-client/src/index.ts"],
       "@rankle/shared/data-models": ["libs/shared/data-models/src/index.ts"]


### PR DESCRIPTION
## Summary
- add ranking-service backend library with hexagonal structure
- expose ranking router via tRPC and include in appRouter
- provide in-memory repo and event bus for initial setup

## Testing
- `npx nx affected:test --base=HEAD~1 --head=HEAD`

------
https://chatgpt.com/codex/tasks/task_e_6872d4cfaf14832baddd78a3ebbce1c7